### PR TITLE
Make secret key ASCII armored

### DIFF
--- a/cli/src/scala/cli/signing/commands/PgpCreate.scala
+++ b/cli/src/scala/cli/signing/commands/PgpCreate.scala
@@ -38,7 +38,7 @@ object PgpCreate extends Command[PgpCreateOptions] {
     val secretKeyContent = {
       val baos   = new ByteArrayOutputStream
       val skr    = keyRingGen.generateSecretKeyRing()
-      val secout = new BufferedOutputStream(baos)
+      val secout = new ArmoredOutputStream(baos)
       skr.encode(secout)
       secout.close()
       baos.toByteArray


### PR DESCRIPTION
ASCII armored secret key can be imported to `gpg`, right now you can't do that with the files generated by `scala-cli-signing`.