### PR TITLE
Fix version string in the published bundle

### DIFF
--- a/build.mill.scala
+++ b/build.mill.scala
@@ -292,7 +292,7 @@ object ci extends Module {
   @unused
   def publishSonatype(tasks: mill.main.Tasks[PublishModule.PublishData]): Command[Unit] =
     Task.Command {
-      val publishVersion = finalPublishVersion
+      val publishVersion = finalPublishVersion()
       System.err.println(s"Publish version: $publishVersion")
       val bundleName = s"$publishOrg-$ghName-$publishVersion"
       System.err.println(s"Publishing bundle: $bundleName")


### PR DESCRIPTION
Before:
https://github.com/VirtusLab/scala-cli-signing/actions/runs/15537096782/job/43751894187#step:6:37
```scala
[239/239] ci.publishSonatype
[239] Publish version: project.publish.finalPublishVersion
[239] Publishing bundle: org.virtuslab.scala-cli-signing-scala-cli-signing-project.publish.finalPublishVersion
[239] Successfully published org.virtuslab.scala-cli-signing-scala-cli-signing-project.publish.finalPublishVersion to Sonatype Central
[2[39](https://github.com/VirtusLab/scala-cli-signing/actions/runs/15537096782/job/43751894187#step:6:40)/239] ================== ci.publishSonatype --tasks __.publishArtifacts ================== 42s
```

After:
```scala
[239] Publish version: 0.2.9
[239] Publishing bundle: org.virtuslab.scala-cli-signing-scala-cli-signing-0.2.9
```