### PR TITLE
Fix error handling checking for a wrong message

### DIFF
--- a/cli/src/scala/cli/signing/util/BouncycastleSigner.scala
+++ b/cli/src/scala/cli/signing/util/BouncycastleSigner.scala
@@ -51,8 +51,7 @@ final case class BouncycastleSigner(
           .build(passwordOpt.map(_.value.toCharArray).getOrElse(Array.empty))
       )
     }.toEither.left.map {
-      case pgpExc: PGPException
-          if pgpExc.getMessage.contains("checksum mismatch at in checksum of") =>
+      case pgpExc: PGPException if pgpExc.getMessage.contains("checksum mismatch") =>
         passwordOpt match {
           case Some(_) =>
             "Failed to decrypt the PGP secret key, make sure the provided password is correct!"


### PR DESCRIPTION
It seems like migrating from deprecated Bouncycastle API in https://github.com/VirtusLab/scala-cli-signing/pull/211 changed the error message from 

> checksum mismatch at in checksum of 20 bytes

to

> checksum mismatch in checksum of 20 bytes

Which makes sense, as there's evidently a typo in the old version.
And we were actually matching our error handling against the old message, which broke signing tests at https://github.com/VirtusLab/scala-cli/pull/3988